### PR TITLE
feat: support per-repo required_approving_review_count override

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -267,6 +267,7 @@ repos:
   osp-component-dashboard:
     default_branch: main
     checks: []
+    required_approving_review_count: 0  # automated bot commits (vuln scans)
 
   coverage-dashboard:
     default_branch: main

--- a/terraform/branch-protection/locals.tf
+++ b/terraform/branch-protection/locals.tf
@@ -15,4 +15,10 @@ locals {
     for repo, cfg in local.config.repos :
     repo => cfg.checks
   }
+
+  # Map of repo -> required approving review count (per-repo override or global default)
+  repo_required_approving_review_count = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(cfg, "required_approving_review_count", var.required_approving_review_count)
+  }
 }

--- a/terraform/branch-protection/main.tf
+++ b/terraform/branch-protection/main.tf
@@ -31,10 +31,13 @@ resource "github_branch_protection" "default" {
     }
   }
 
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = var.dismiss_stale_reviews
-    require_code_owner_reviews      = var.require_code_owner_reviews
-    required_approving_review_count = var.required_approving_review_count
+  dynamic "required_pull_request_reviews" {
+    for_each = local.repo_required_approving_review_count[each.key] > 0 ? [1] : []
+    content {
+      dismiss_stale_reviews           = var.dismiss_stale_reviews
+      require_code_owner_reviews      = var.require_code_owner_reviews
+      required_approving_review_count = local.repo_required_approving_review_count[each.key]
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Allow individual repos in `repos.yaml` to override `required_approving_review_count`. When set to `0`, the `required_pull_request_reviews` block is omitted entirely — removing the PR review requirement and allowing direct pushes.

## Motivation

`osp-component-dashboard` has a scheduled GitHub Actions workflow that scans for vulnerabilities and commits updated data files. The branch protection review requirement causes the workflow to fail because `github-actions[bot]` can't push directly to `main`.

Setting `required_approving_review_count: 0` for this repo lets the bot push directly while all other repos keep the default (1 review required).

## Changes

- **`config/repos.yaml`**: Added `required_approving_review_count: 0` for `osp-component-dashboard`
- **`terraform/branch-protection/locals.tf`**: New `repo_required_approving_review_count` map that reads per-repo overrides, falling back to the global variable
- **`terraform/branch-protection/main.tf`**: Made `required_pull_request_reviews` a dynamic block — only included when count > 0