### PR TITLE
fix: remove pac-boussole from branch protection config

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -81,11 +81,6 @@ repos:
     default_branch: main
     checks: []
 
-  # -- Pipelines as Code --
-  pac-boussole:
-    default_branch: main
-    checks: []
-
   # -- Tasks --
   task-buildpacks:
     default_branch: main


### PR DESCRIPTION
The GitHub App doesn't have admin access to `pac-boussole`, causing all terraform plan/apply runs to fail with `Resource not accessible by integration`.

Removing it from the config unblocks the pipeline. The branch protection for pac-boussole can be re-added once the app permissions are fixed.

**Note:** After merging, we'll need to run `terraform state rm` for the pac-boussole resources before apply will work cleanly.