### PR TITLE
feat: migrate branch protection to repository rulesets (Phase 1)

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -1,19 +1,23 @@
-# Single source of truth for openshift-pipelines branch-protection.
+# Single source of truth for openshift-pipelines repository protection.
 #
-# Every repo listed here gets:
-#   - main (or master) branch protection with the org-wide baseline
-#   - Optional per-repo required status checks
-#   - Optional release-branch protection (release-* pattern)
+# Every repo listed here gets a "default" repository ruleset with:
+#   - No force pushes (non_fast_forward)
+#   - No branch deletion (deletion)
+#   - PR review requirements (configurable per-repo)
+#   - Optional required status checks
+#   - Admin bypass enabled
 #
-# Baseline rules (defined in terraform variables):
-#   - No force pushes
-#   - No branch deletion
-#   - Require 1 approving review
-#   - Dismiss stale reviews on new pushes
-#   - No admin bypass
-#
-# Per-repo "checks" are additive required status-check contexts.
-# Leave empty ([]) for repos with no CI status checks.
+# Per-repo fields:
+#   default_branch:                   Branch name (main, master, etc.)
+#   checks:                           Required status check contexts ([] for none)
+#   required_approving_review_count:  Override approval count (default: 1, set 0 for bot repos)
+#   ruleset:                          Extra ruleset config overrides (optional)
+#     branches:                       Extra branch patterns beyond default+release (optional)
+#     allowed_merge_methods:          Merge method restriction (optional, default: all)
+#     required_linear_history:        Require linear history (optional, default: false)
+#     merge_queue:                    Merge queue config (optional)
+#     copilot_code_review:            Enable Copilot review (optional, default: false)
+#     require_code_owner_review:      Require CODEOWNERS review (optional, default: false)
 
 # -------------------------------------------------------------------
 # Core platform repos
@@ -22,7 +26,9 @@ repos:
   tektoncd-pruner:
     default_branch: main
     checks: []
-    required_approving_review_count: 0  # has ruleset with approval=0
+    required_approving_review_count: 0  # has ruleset with approval=0, branch protection must match
+    ruleset:
+      allowed_merge_methods: ["rebase"]
 
   tektoncd-catalog:
     default_branch: main
@@ -36,7 +42,15 @@ repos:
   operator:
     default_branch: main
     checks: []
-    required_approving_review_count: 0  # has ruleset, branch protection blocks automation
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
+      required_linear_history: true
+      copilot_code_review: true
+      status_checks:
+        - context: "tide"
+          integration_id: 412865
 
   operator-downgrade:
     default_branch: main
@@ -50,6 +64,10 @@ repos:
   release-tests:
     default_branch: master
     checks: []
+    ruleset:
+      allowed_merge_methods: ["squash"]
+      required_linear_history: true
+      no_branch_creation: true
 
   release-tests-ginkgo:
     default_branch: main
@@ -84,6 +102,17 @@ repos:
     default_branch: main
     checks: []
     required_approving_review_count: 0  # Konflux fork — automated PRs
+    ruleset:
+      branches: ["refs/heads/next", "refs/heads/release-v1.22.x"]
+      copilot_code_review: true
+      merge_queue:
+        merge_method: "REBASE"
+        max_entries_to_build: 1
+        min_entries_to_merge: 1
+        max_entries_to_merge: 5
+        min_entries_to_merge_wait_minutes: 5
+        grouping_strategy: "ALLGREEN"
+        check_response_timeout_minutes: 60
 
   # -- Tasks --
   task-buildpacks:
@@ -114,6 +143,8 @@ repos:
   pipeline-service-exporter:
     default_branch: main
     checks: []
+    ruleset:
+      allowed_merge_methods: ["rebase", "squash"]
 
   pipeline-service-workspace-controller:
     default_branch: main
@@ -142,6 +173,8 @@ repos:
     default_branch: main
     checks: []
     required_approving_review_count: 0  # Konflux fork — automated PRs
+    ruleset:
+      required_linear_history: true
 
   p12n-multicluster-proxy-aae:
     default_branch: main
@@ -157,6 +190,8 @@ repos:
     default_branch: main
     checks: []
     required_approving_review_count: 0  # Konflux fork — automated PRs
+    ruleset:
+      allowed_merge_methods: ["rebase", "squash"]
 
   p12n-tekton-assist:
     default_branch: main
@@ -172,7 +207,9 @@ repos:
   manual-approval-gate:
     default_branch: main
     checks: []
-    required_approving_review_count: 0  # has ruleset with approval=0
+    required_approving_review_count: 0  # has ruleset with approval=0, branch protection must match
+    ruleset:
+      allowed_merge_methods: ["rebase"]
 
   multicluster-proxy-aae:
     default_branch: main
@@ -189,11 +226,25 @@ repos:
   tekton-assist:
     default_branch: next
     checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/main"]
+      require_code_owner_review: true
+      copilot_code_review: true
 
   tekton-caches:
     default_branch: main
     checks: []
-    required_approving_review_count: 0  # has ruleset with approval=0
+    required_approving_review_count: 0  # has ruleset with approval=0, branch protection must match
+    ruleset:
+      allowed_merge_methods: ["rebase"]
+      status_checks:
+        - context: "go"
+          integration_id: 15368
+        - context: "e2e tests"
+          integration_id: 15368
+        - context: "publish latest"
+          integration_id: 15368
 
   tekton-kueue:
     default_branch: main
@@ -214,6 +265,8 @@ repos:
   must-gather:
     default_branch: main
     checks: []
+    ruleset:
+      allowed_merge_methods: ["rebase", "squash"]
 
   # -- Docs, examples, misc --
   architecture:
@@ -296,9 +349,99 @@ repos:
     default_branch: main
     checks: []
 
-  # -- Misc --
   jenkins-to-tekton:
     default_branch: main
     checks: []
 
+  # -------------------------------------------------------------------
+  # Upstream forks (Konflux-managed, automated PRs only)
+  # -------------------------------------------------------------------
+  tektoncd-pipeline:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
 
+  tektoncd-chains:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
+
+  tektoncd-cli:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
+
+  tektoncd-triggers:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
+
+  tektoncd-results:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      copilot_code_review: true
+
+  tektoncd-hub:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
+
+  tektoncd-git-clone:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+
+  tektoncd-results-for-konflux:
+    default_branch: downstream-0.14.0-2
+    checks: []
+    required_approving_review_count: 0
+
+  tektoncd-plumbing:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+
+  pac-downstream:
+    default_branch: main
+    checks: []
+    required_approving_review_count: 0
+    ruleset:
+      branches: ["refs/heads/next"]
+      allowed_merge_methods: ["rebase"]
+
+  hub:
+    default_branch: main
+    checks: []
+
+  kueue:
+    default_branch: main
+    checks: []
+
+  operator-multicluster:
+    default_branch: main
+    checks: []
+
+  pipelines-tutorial:
+    default_branch: master
+    checks: []
+
+  lightspeed-rag-content:
+    default_branch: main
+    checks: []

--- a/terraform/branch-protection/imports.tf
+++ b/terraform/branch-protection/imports.tf
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------
+# Import existing manually-created rulesets named "default"
+# These will be adopted by Terraform and managed going forward.
+# Remove this file after the first successful apply.
+# -----------------------------------------------------------------
+
+import {
+  to = github_repository_ruleset.default["tektoncd-pruner"]
+  id = "tektoncd-pruner:3276049"
+}
+
+import {
+  to = github_repository_ruleset.default["operator"]
+  id = "operator:2090492"
+}
+
+import {
+  to = github_repository_ruleset.default["manual-approval-gate"]
+  id = "manual-approval-gate:3276063"
+}
+
+import {
+  to = github_repository_ruleset.default["tektoncd-pipeline"]
+  id = "tektoncd-pipeline:2183775"
+}
+
+import {
+  to = github_repository_ruleset.default["tektoncd-chains"]
+  id = "tektoncd-chains:2204695"
+}
+
+import {
+  to = github_repository_ruleset.default["tektoncd-cli"]
+  id = "tektoncd-cli:2204720"
+}
+
+import {
+  to = github_repository_ruleset.default["tektoncd-triggers"]
+  id = "tektoncd-triggers:2204745"
+}
+
+import {
+  to = github_repository_ruleset.default["tektoncd-hub"]
+  id = "tektoncd-hub:2204727"
+}
+
+import {
+  to = github_repository_ruleset.default["pac-downstream"]
+  id = "pac-downstream:3276077"
+}

--- a/terraform/branch-protection/locals.tf
+++ b/terraform/branch-protection/locals.tf
@@ -10,7 +10,7 @@ locals {
     repo => cfg.default_branch
   }
 
-  # Map of repo -> list of required status check contexts
+  # Map of repo -> list of required status check contexts (from flat "checks" field)
   repo_checks = {
     for repo, cfg in local.config.repos :
     repo => cfg.checks
@@ -21,4 +21,73 @@ locals {
     for repo, cfg in local.config.repos :
     repo => lookup(cfg, "required_approving_review_count", var.required_approving_review_count)
   }
+
+  # ---------------------------------------------------------------------------
+  # Ruleset locals
+  # ---------------------------------------------------------------------------
+
+  # Per-repo ruleset overrides (empty map if not specified)
+  repo_ruleset = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(cfg, "ruleset", {})
+  }
+
+  # Branch patterns for each repo's ruleset
+  # Always include ~DEFAULT_BRANCH and release-*, plus any extra branches
+  repo_ruleset_branches = {
+    for repo, cfg in local.config.repos :
+    repo => distinct(concat(
+      ["~DEFAULT_BRANCH", "refs/heads/release-*"],
+      lookup(lookup(cfg, "ruleset", {}), "branches", [])
+    ))
+  }
+
+  # Status checks: merge flat "checks" field with ruleset.status_checks
+  # The flat "checks" field has no integration_id; ruleset.status_checks can specify one
+  repo_ruleset_status_checks = {
+    for repo, cfg in local.config.repos :
+    repo => concat(
+      # From flat checks field (no integration_id)
+      [for ctx in cfg.checks : { context = ctx, integration_id = null }],
+      # From ruleset.status_checks (with optional integration_id)
+      lookup(lookup(cfg, "ruleset", {}), "status_checks", [])
+    )
+  }
+
+  # Allowed merge methods (default: all methods allowed)
+  repo_allowed_merge_methods = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(lookup(cfg, "ruleset", {}), "allowed_merge_methods", [])
+  }
+
+  # Linear history
+  repo_required_linear_history = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(lookup(cfg, "ruleset", {}), "required_linear_history", false)
+  }
+
+  # Code owner review
+  repo_require_code_owner_review = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(lookup(cfg, "ruleset", {}), "require_code_owner_review", false)
+  }
+
+  # Copilot code review
+  repo_copilot_code_review = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(lookup(cfg, "ruleset", {}), "copilot_code_review", false)
+  }
+
+  # Merge queue config (null if not set)
+  repo_merge_queue = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(lookup(cfg, "ruleset", {}), "merge_queue", null)
+  }
+
+  # No branch creation (for release-tests style repos)
+  repo_no_branch_creation = {
+    for repo, cfg in local.config.repos :
+    repo => lookup(lookup(cfg, "ruleset", {}), "no_branch_creation", false)
+  }
+
 }

--- a/terraform/branch-protection/outputs.tf
+++ b/terraform/branch-protection/outputs.tf
@@ -1,10 +1,10 @@
 output "protected_repos" {
-  description = "List of repositories with branch protection applied"
+  description = "List of repositories with protection applied"
   value       = local.all_repos
 }
 
 output "default_branch_protections" {
-  description = "Default-branch protection resource IDs"
+  description = "Default-branch protection resource IDs (legacy — will be removed)"
   value = {
     for repo in local.all_repos :
     repo => github_branch_protection.default[repo].id
@@ -12,9 +12,17 @@ output "default_branch_protections" {
 }
 
 output "release_branch_protections" {
-  description = "Release-branch protection resource IDs"
+  description = "Release-branch protection resource IDs (legacy — will be removed)"
   value = {
     for repo in local.all_repos :
     repo => github_branch_protection.releases[repo].id
+  }
+}
+
+output "rulesets" {
+  description = "Repository ruleset IDs"
+  value = {
+    for repo in local.all_repos :
+    repo => github_repository_ruleset.default[repo].ruleset_id
   }
 }

--- a/terraform/branch-protection/rulesets.tf
+++ b/terraform/branch-protection/rulesets.tf
@@ -1,0 +1,97 @@
+# -----------------------------------------------------------------
+# Repository rulesets for every repo in config/repos.yaml
+#
+# Replaces github_branch_protection with the newer rulesets API.
+# Each repo gets a single "default" ruleset covering default branch
+# and release branches, with per-repo overrides from config.
+# -----------------------------------------------------------------
+
+resource "github_repository_ruleset" "default" {
+  for_each = toset(local.all_repos)
+
+  name        = "default"
+  repository  = each.key
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = local.repo_ruleset_branches[each.key]
+      exclude = []
+    }
+  }
+
+  # Org admins can bypass
+  bypass_actors {
+    actor_id    = 0
+    actor_type  = "OrganizationAdmin"
+    bypass_mode = "always"
+  }
+
+  # Repo admins can bypass
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # -- Always enabled --
+    deletion         = true
+    non_fast_forward = true
+
+    # -- Optional: block branch creation on protected patterns --
+    creation = local.repo_no_branch_creation[each.key]
+
+    # -- Optional: linear history --
+    required_linear_history = local.repo_required_linear_history[each.key]
+
+    # -- PR reviews + merge method enforcement --
+    # Always included: enforces merge method (rebase-only default) and PR reviews
+    pull_request {
+      required_approving_review_count   = local.repo_required_approving_review_count[each.key]
+      dismiss_stale_reviews_on_push     = local.repo_required_approving_review_count[each.key] > 0 ? var.dismiss_stale_reviews : false
+      require_code_owner_review         = local.repo_require_code_owner_review[each.key]
+      require_last_push_approval        = false
+      required_review_thread_resolution = false
+      allowed_merge_methods             = length(local.repo_allowed_merge_methods[each.key]) > 0 ? local.repo_allowed_merge_methods[each.key] : ["rebase"]
+    }
+
+    # -- Required status checks --
+    dynamic "required_status_checks" {
+      for_each = length(local.repo_ruleset_status_checks[each.key]) > 0 ? [1] : []
+      content {
+        dynamic "required_check" {
+          for_each = local.repo_ruleset_status_checks[each.key]
+          content {
+            context        = required_check.value.context
+            integration_id = required_check.value.integration_id
+          }
+        }
+      }
+    }
+
+    # -- Merge queue --
+    dynamic "merge_queue" {
+      for_each = local.repo_merge_queue[each.key] != null ? [local.repo_merge_queue[each.key]] : []
+      content {
+        merge_method                      = merge_queue.value.merge_method
+        max_entries_to_build              = merge_queue.value.max_entries_to_build
+        min_entries_to_merge              = merge_queue.value.min_entries_to_merge
+        max_entries_to_merge              = merge_queue.value.max_entries_to_merge
+        min_entries_to_merge_wait_minutes = merge_queue.value.min_entries_to_merge_wait_minutes
+        grouping_strategy                 = merge_queue.value.grouping_strategy
+        check_response_timeout_minutes    = merge_queue.value.check_response_timeout_minutes
+      }
+    }
+
+    # -- Copilot code review --
+    dynamic "copilot_code_review" {
+      for_each = local.repo_copilot_code_review[each.key] ? [1] : []
+      content {
+        review_on_push             = true
+        review_draft_pull_requests = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Phase 1 of migrating from `github_branch_protection` to `github_repository_ruleset`.

Rulesets are GitHub's newer, more powerful branch protection system. They support layering, bypass actors, merge queues, Copilot code review, and merge method enforcement — all things branch protection can't do.

## Changes

### New `rulesets.tf`
Every repo gets a `default` ruleset covering `~DEFAULT_BRANCH` + `refs/heads/release-*`, with:
- No force pushes, no branch deletion
- PR review requirements (per-repo: 0 for bot repos, 1 for human repos)
- **Rebase-only merge method** enforced by default
- OrgAdmin + RepoAdmin bypass

### Expanded `repos.yaml`
- **15 fork repos added** (tektoncd-\*, pac-downstream, hub, kueue, etc.) — full coverage
- All automated/bot repos set to `required_approving_review_count: 0`
- Per-repo overrides preserved from existing manual rulesets:
  - `operator`: copilot review, tide status check, linear history
  - `p12n-console-plugin`: merge queue, copilot review
  - `tekton-caches`: go/e2e/publish status checks
  - `tekton-assist`: codeowner review, copilot review
  - `release-tests`: squash-only, linear history, no branch creation

### Imports
9 existing manually-created `default` rulesets imported into Terraform state.

### Merge method enforcement
| Policy | Repos |
|--------|-------|
| Rebase only | ~74 repos (default) |
| Squash only | release-tests |
| Rebase + squash | pipeline-service-exporter, must-gather, p12n-syncer-service |

## Phase 1 vs Phase 2

**This PR is Phase 1** — rulesets are created **alongside** existing branch protection. Both are active; most restrictive wins. This is safe and non-destructive.

**Phase 2** (separate PR after verification):
1. Remove `github_branch_protection.default` and `github_branch_protection.releases` from `main.tf`
2. Delete old manually-created rulesets with non-\default\ names
3. Remove `imports.tf`

## How to apply

After merge:
1. Go to Actions → Branch Protection → Run workflow → select `apply`
2. Verify rulesets are active on a few repos
3. Proceed with Phase 2 PR