### PR TITLE
fix: set approval=0 for repos with existing rulesets (tektoncd-pruner, manual-approval-gate, tekton-caches)

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -22,6 +22,7 @@ repos:
   tektoncd-pruner:
     default_branch: main
     checks: []
+    required_approving_review_count: 0  # has ruleset with approval=0
 
   tektoncd-catalog:
     default_branch: main
@@ -171,6 +172,7 @@ repos:
   manual-approval-gate:
     default_branch: main
     checks: []
+    required_approving_review_count: 0  # has ruleset with approval=0
 
   multicluster-proxy-aae:
     default_branch: main
@@ -191,6 +193,7 @@ repos:
   tekton-caches:
     default_branch: main
     checks: []
+    required_approving_review_count: 0  # has ruleset with approval=0
 
   tekton-kueue:
     default_branch: main


### PR DESCRIPTION
These 3 repos have manually-created rulesets with `required_approving_review_count: 0`, but the Terraform-managed branch protection still requires 1 approval. Most restrictive wins → automated PRs blocked.

Aligns branch protection with the existing ruleset settings.

Same pattern as PR #12 for p12n-* repos.